### PR TITLE
Fixed EOF error by trying to run cf command

### DIFF
--- a/bin/cf-wrapper
+++ b/bin/cf-wrapper
@@ -28,7 +28,7 @@ plugins=(
 # doctor ?
 # open ? 
 [[ -s ~/.cf/plugins/config.json ]] || 
-  { mkdir -p ~/.cf/plugins && echo '{}' > ~/.cf/plugins/config.json}
+  { mkdir -p ~/.cf/plugins && echo '{}' > ~/.cf/plugins/config.json; }
 installed=()
 while read -r name
 do installed+=(name)


### PR DESCRIPTION
Fixing issue #34

There was a syntax error in the cf-wrapper script